### PR TITLE
feat: Init id on apply if missing in serviceDefinition

### DIFF
--- a/src/serviceDefinition/delete.ts
+++ b/src/serviceDefinition/delete.ts
@@ -1,4 +1,8 @@
-import { loadServiceDefinition } from './loading';
+/*
+ * Copyright 2022 steadybit GmbH. All rights reserved.
+ */
+
+import { loadServiceDefinition } from './files';
 import { abortExecution } from '../errors';
 import { executeApiCall } from '../api';
 

--- a/src/serviceDefinition/files.test.ts
+++ b/src/serviceDefinition/files.test.ts
@@ -1,12 +1,16 @@
+/*
+ * Copyright 2022 steadybit GmbH. All rights reserved.
+ */
+
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs/promises';
 import { tmpdir } from 'os';
 import yaml from 'js-yaml';
 import path from 'path';
 
-import { loadServiceDefinition } from './loading';
+import { loadServiceDefinition, writeServiceDefinition } from './files';
 
-describe('serviceDefinition/loading', () => {
+describe('serviceDefinition/files', () => {
   describe('loadServiceDefinition', () => {
     const fileWithSyntaxErrors = path.join(tmpdir(), `${uuidv4()}-syntax-errors.json`);
     const fileWithValidJson = path.join(tmpdir(), `${uuidv4()}-valid.json`);
@@ -15,8 +19,8 @@ describe('serviceDefinition/loading', () => {
     beforeAll(async () => {
       await Promise.all([
         fs.writeFile(fileWithSyntaxErrors, '{$$$42:'),
-        fs.writeFile(fileWithValidJson, JSON.stringify({type: 'json'})),
-        fs.writeFile(fileWithValidYaml, yaml.dump({type: 'yaml'}))
+        fs.writeFile(fileWithValidJson, JSON.stringify({ type: 'json' })),
+        fs.writeFile(fileWithValidYaml, yaml.dump({ type: 'yaml' }))
       ]);
     });
 
@@ -55,4 +59,23 @@ Object {
     });
   });
 
+  describe('writeServiceDefinition', () => {
+    const outputfile = path.join(tmpdir(), `${uuidv4()}-valid.yml`);
+
+    afterAll(async () => {
+      await Promise.all([
+        fs.unlink(outputfile)
+      ]);
+    });
+
+    it('must successfully write YAML files', async () => {
+      await writeServiceDefinition(outputfile, { id: '00000000-0000-0000-0000-000000000000', name: 'Test ServiceDefinition', mapping: {} });
+
+      expect((await fs.readFile(outputfile)).toString()).toEqual(`id: 00000000-0000-0000-0000-000000000000
+name: Test ServiceDefinition
+mapping: {}
+`);
+    });
+
+  });
 });

--- a/src/serviceDefinition/files.ts
+++ b/src/serviceDefinition/files.ts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 steadybit GmbH. All rights reserved.
+ */
+
 import fs from 'fs/promises';
 import yaml from 'js-yaml';
 
@@ -25,4 +29,9 @@ export async function loadServiceDefinition(serviceDefinitionPath: string): Prom
       (e as Error)?.message ?? 'Unknown Cause'
     );
   }
+}
+
+export async function writeServiceDefinition(serviceDefinitionPath: string, serviceDefinition: ServiceDefinition): Promise<void> {
+  const fileContent = yaml.dump(serviceDefinition);
+  await fs.writeFile(serviceDefinitionPath, fileContent, { encoding: 'utf8' });
 }

--- a/src/serviceDefinition/init.ts
+++ b/src/serviceDefinition/init.ts
@@ -1,23 +1,26 @@
+/*
+ * Copyright 2022 steadybit GmbH. All rights reserved.
+ */
+
 import { v4 as uuidv4 } from 'uuid';
 import colors from 'colors/safe';
 import inquirer from 'inquirer';
-import fs from 'fs/promises';
 import yaml from 'js-yaml';
 import path from 'path';
 
-import { ServiceDefinition, Parameters, KubernetesMapping } from './types';
+import { KubernetesMapping, Parameters, ServiceDefinition } from './types';
 import { validateHttpUrl, validateNotBlank } from '../prompt/validation';
 import { confirm } from '../prompt/confirm';
+import { writeServiceDefinition } from './files';
 
 export async function init() {
   const serviceDefinition = await askForServiceDefinitionInformation();
 
   const outputFile = path.join(process.cwd(), '.steadybit.yml');
-  const fileContent = yaml.dump(serviceDefinition);
 
   console.log(`About to write to ${colors.bold(outputFile)}:`);
   console.log();
-  console.log(fileContent);
+  console.log(yaml.dump(serviceDefinition));
   console.log();
 
   const ok = await confirm('Should we create this file?');
@@ -26,11 +29,11 @@ export async function init() {
   }
   console.log();
 
-  fs.writeFile(outputFile, fileContent);
+  await writeServiceDefinition(outputFile, serviceDefinition)
 
   console.log('File created!');
   console.log('You can now upload the service definition by executing');
-  console.log('  ' + colors.bold('steadybit service apply .steadybit.yml'));
+  console.log(`  ${colors.bold('steadybit service apply .steadybit.yml')}`);
 }
 
 async function askForServiceDefinitionInformation(): Promise<ServiceDefinition> {

--- a/src/serviceDefinition/open.ts
+++ b/src/serviceDefinition/open.ts
@@ -1,7 +1,11 @@
+/*
+ * Copyright 2022 steadybit GmbH. All rights reserved.
+ */
+
 import opn from 'open';
 
 import { abortExecution, abortExecutionWithError } from '../errors';
-import { loadServiceDefinition } from './loading';
+import { loadServiceDefinition } from './files';
 import { executeApiCall } from '../api';
 
 const errorPrefix = 'Failed to identify deep link to the Steadybit UI. ';

--- a/src/serviceDefinition/verify.ts
+++ b/src/serviceDefinition/verify.ts
@@ -1,8 +1,12 @@
-import { red, bold, green, blue, gray } from 'colors/safe';
+/*
+ * Copyright 2022 steadybit GmbH. All rights reserved.
+ */
 
-import { TaskState, ServiceState } from './types';
+import { blue, bold, gray, green, red } from 'colors/safe';
+
+import { ServiceState, TaskState } from './types';
 import { abortExecutionWithError } from '../errors';
-import { loadServiceDefinition } from './loading';
+import { loadServiceDefinition } from './files';
 import { executeApiCall } from '../api';
 
 const taskSuffix: Record<TaskState, string> = {


### PR DESCRIPTION
When the Id is not set in the service definition we initialise it.
This is useful when copying the service definitions from our samples, which omit the id on purpose.