### PR TITLE
Prepare execution of a single experiment

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2022 Steadybit GmbH
 
+import fetch, { Response } from 'node-fetch';
+import { getHeaders, toUrl } from './common';
+
 /*
  * This is required because we are supporting Node.js v14
  */
 import { AbortController } from 'node-abort-controller';
-import fetch, { Response } from 'node-fetch';
-import https from 'https';
-import http from 'http';
-
 import { ensurePlatformAccessConfigurationIsAvailable } from '../config/requirePlatformAccess';
-import { getHeaders, toUrl } from './common';
+import http from 'http';
+import https from 'https';
 
 export interface ApiCallArguments {
   path: string;
@@ -21,6 +21,7 @@ export interface ApiCallArguments {
   expect2xx?: boolean; // defaults to true
   // https://github.com/node-fetch/node-fetch#manual-redirect
   redirect?: 'manual' | 'error';
+  fullyQualifiedUrl?: boolean;
 }
 
 const httpAgentOptions = {
@@ -41,9 +42,10 @@ export async function executeApiCall({
   timeout = 30000,
   expect2xx = true,
   redirect = 'error',
+  fullyQualifiedUrl = false,
 }: ApiCallArguments): Promise<Response> {
   await ensurePlatformAccessConfigurationIsAvailable();
-  const url = await toUrl(path, queryParameters);
+  const url = fullyQualifiedUrl ? path : await toUrl(path, queryParameters);
   const headers = await getHeaders();
 
   const controller = new AbortController();

--- a/src/cli/steadybit-experiment.ts
+++ b/src/cli/steadybit-experiment.ts
@@ -11,8 +11,13 @@ const program = new Command();
 program
   .command('exec')
   .description('Executes an experiment run.')
-  .requiredOption('-key, --key <key>', 'The experiment key.')
+  .requiredOption('-k, --key <key>', 'The experiment key.')
   .option('--no-wait', 'Do not wait for experiment execution to finish.')
+  .option(
+    '--yes',
+    'Skip the prompt asking for experiment execution confirmation. Not necessary when no TTY is attached.',
+    false
+  )
   .action(requirePlatformAccess(execute));
 
 program.parseAsync(process.argv);

--- a/src/cli/steadybit-experiment.ts
+++ b/src/cli/steadybit-experiment.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+import { Command } from 'commander';
+import { execute } from '../experiment/exec';
+import { requirePlatformAccess } from './requirements';
+
+const program = new Command();
+
+program
+  .command('exec')
+  .description('Executes an experiment run.')
+  .requiredOption('-key, --key <key>', 'The experiment key.')
+  .option('--no-wait', 'Do not wait for experiment execution to finish.')
+  .action(requirePlatformAccess(execute));
+
+program.parseAsync(process.argv);

--- a/src/cli/steadybit-service-definition.ts
+++ b/src/cli/steadybit-service-definition.ts
@@ -3,16 +3,15 @@
 // SPDX-FileCopyrightText: 2022 Steadybit GmbH
 
 import { Command } from 'commander';
-
+import { apply } from '../serviceDefinition/apply';
 import { deleteServiceDefinition } from '../serviceDefinition/delete';
+import { exec } from '../serviceDefinition/exec';
+import { init } from '../serviceDefinition/init';
+import { open } from '../serviceDefinition/open';
+import { requirePlatformAccess } from './requirements';
+import { show } from '../serviceDefinition/show';
 import { validateSemverRangeCommanderArgument } from '../semver';
 import { verify } from '../serviceDefinition/verify';
-import { apply } from '../serviceDefinition/apply';
-import { open } from '../serviceDefinition/open';
-import { init } from '../serviceDefinition/init';
-import { exec } from '../serviceDefinition/exec';
-import { show } from '../serviceDefinition/show';
-import { requirePlatformAccess } from './requirements';
 
 const program = new Command();
 
@@ -27,10 +26,7 @@ program
   .option('-f, --file <file>', 'Path to the service definition file.', '.steadybit.yml')
   .description('Deletes a service definition.')
   .action(requirePlatformAccess(deleteServiceDefinition));
-program
-  .command('init')
-  .description('Initialize a service definition file.')
-  .action(requirePlatformAccess(init));
+program.command('init').description('Initialize a service definition file.').action(requirePlatformAccess(init));
 program
   .command('open')
   .option('-f, --file <file>', 'Path to the service definition file.', '.steadybit.yml')
@@ -46,11 +42,21 @@ program
 program
   .command('exec')
   .option('--no-wait', 'Do not wait for task executions to finish.')
-  .option('--yes', 'Skip the prompt asking for experiment execution confirmation. Not necessary when no TTY is attached.', false)
-  .option('--no-error-on-empty-task-set', 'Whether to end the process with an error when an execution is triggered for an empty set of tasks.')
+  .option(
+    '--yes',
+    'Skip the prompt asking for experiment execution confirmation. Not necessary when no TTY is attached.',
+    false
+  )
+  .option(
+    '--no-error-on-empty-task-set',
+    'Whether to end the process with an error when an execution is triggered for an empty set of tasks.'
+  )
   .option('--no-error-on-task-failure', 'Whether to end the process with an error when an executed task fails.')
   .option('-f, --file <file>', 'Path to the service definition file.', '.steadybit.yml')
-  .option('-t, --task <tasks...>', 'Optional filter to limit execution to those tasks matching the given task name. Can appear multiple times')
+  .option(
+    '-t, --task <tasks...>',
+    'Optional filter to limit execution to those tasks matching the given task name. Can appear multiple times'
+  )
   .option('-pp, --print-parameters', 'Print task parameters when listing tasks.')
   .option('-pm, --print-matrix-context', 'Print the matrix execution context information when listing tasks.')
   .description('Execute tasks defined for a service.')

--- a/src/cli/steadybit.ts
+++ b/src/cli/steadybit.ts
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: 2022 Steadybit GmbH
 
 import { Command } from 'commander';
-import { satisfies } from 'semver';
 import colors from 'colors/safe';
+import { satisfies } from 'semver';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const requiredNodejsVersion = require('../../package.json').engines.node;
@@ -36,4 +36,5 @@ new Command()
   .command('def-repo', 'Change tags and verify a task/policy definition repository state.')
   .command('service', 'Alias for the "service-definition" command.')
   .command('service-definition', 'Configure or verify service definitions.')
+  .command('experiment', 'Check and execute experiments.')
   .parseAsync(process.argv);

--- a/src/experiment/api.ts
+++ b/src/experiment/api.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+import { ExecuteResult, ExecutionResult } from './types';
+
+import { abortExecutionWithError } from '../errors';
+import { executeApiCall } from '../api/http';
+
+export async function executeExperiment(key: string): Promise<ExecuteResult> {
+  try {
+    const response = await executeApiCall({
+      method: 'POST',
+      path: `/api/experiments/${encodeURIComponent(key)}/execute`,
+    });
+    return { location: response.headers.get('Location') ?? '' };
+  } catch (e) {
+    const error = await abortExecutionWithError(e, 'Failed to execute task %s (%s@%s)', key);
+    throw error;
+  }
+}
+
+export async function getExperimentExecution(path: string): Promise<ExecutionResult> {
+  try {
+    const response = await executeApiCall({
+      method: 'GET',
+      path,
+      fullyQualifiedUrl: true,
+    });
+    return (await response.json()) as ExecutionResult;
+  } catch (e) {
+    const error = await abortExecutionWithError(e, 'Failed to get experiment execution ');
+    throw error;
+  }
+}

--- a/src/experiment/exec/execution.ts
+++ b/src/experiment/exec/execution.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+import { filter, firstValueFrom, from, interval, map, switchMap, tap } from 'rxjs';
+import { getExperimentExecution, executeExperiment as sendExecuteExperimentHttpRequest } from '../api';
+
+import { Options } from './types';
+
+export async function executeExperiment(options: Options): Promise<boolean | undefined> {
+  const result = await executeSingle(options);
+  return result;
+}
+
+async function executeSingle(options: Options): Promise<boolean | undefined> {
+  const experimentKey = options.key;
+  console.log('Executing experiment:', experimentKey);
+
+  const result = await sendExecuteExperimentHttpRequest(options.key);
+  console.log('Experiment execution:', result.location);
+
+  if (!options.wait || !result.location) {
+    return undefined;
+  }
+
+  return await firstValueFrom(
+    interval(5000)
+      .pipe(switchMap(() => from(getExperimentExecution(result.location ?? ''))))
+      .pipe(tap(e => console.log('Current execution state:', e.state.toLowerCase())))
+      .pipe(filter(e => e.state === 'FAILED' || e.state === 'CANCELED' || e.state === 'COMPLETED'))
+      .pipe(map(() => true))
+  );
+}

--- a/src/experiment/exec/execution.ts
+++ b/src/experiment/exec/execution.ts
@@ -27,6 +27,6 @@ async function executeSingle(options: Options): Promise<boolean | undefined> {
       .pipe(switchMap(() => from(getExperimentExecution(result.location ?? ''))))
       .pipe(tap(e => console.log('Current execution state:', e.state.toLowerCase())))
       .pipe(filter(e => e.state === 'FAILED' || e.state === 'CANCELED' || e.state === 'COMPLETED'))
-      .pipe(map(() => true))
+      .pipe(map(e => (e.state === 'COMPLETED' ? true : false)))
   );
 }

--- a/src/experiment/exec/index.ts
+++ b/src/experiment/exec/index.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+import { Options } from './types';
+import { confirm } from '../../prompt/confirm';
+import { executeExperiment } from './execution';
+
+export async function execute(options: Options) {
+  if (!options.yes) {
+    const confirmation = await confirm('Are you sure you want to execute the experiment?', {
+      defaultYes: false,
+      defaultWhenNonInteractive: true,
+    });
+    if (!confirmation) {
+      process.exit(0);
+    }
+  }
+
+  const successful = await executeExperiment(options);
+  process.exit(successful === false ? 1 : 0);
+}

--- a/src/experiment/exec/types.d.ts
+++ b/src/experiment/exec/types.d.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+export interface Options {
+  key: string;
+  yes: boolean;
+  wait: boolean;
+}

--- a/src/experiment/types.d.ts
+++ b/src/experiment/types.d.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+export type ExecuteResult = {
+  location?: string;
+};
+
+export type ExecutionResult = {
+  state: string;
+};


### PR DESCRIPTION
# Why

Mano-mano would like to execute single experiment runs via CLI.

# What

Adding a new command `experiment` with a single sub-command `exec`. There are two options, one mandatory `-k` experiment-key and an optional `--no-wait` one.
In contrast to the tasks endpoint, we need to fetch the current state by hand here.