### PR TITLE
Use POST endpoint to define new services

### DIFF
--- a/src/serviceDefinition/files.test.ts
+++ b/src/serviceDefinition/files.test.ts
@@ -19,26 +19,24 @@ describe('serviceDefinition/files', () => {
       await Promise.all([
         fs.writeFile(fileWithSyntaxErrors, '{$$$42:'),
         fs.writeFile(fileWithValidJson, JSON.stringify({ type: 'json' })),
-        fs.writeFile(fileWithValidYaml, yaml.dump({ type: 'yaml' }))
+        fs.writeFile(fileWithValidYaml, yaml.dump({ type: 'yaml' })),
       ]);
     });
 
     afterAll(async () => {
-      await Promise.all([
-        fs.unlink(fileWithSyntaxErrors),
-        fs.unlink(fileWithValidJson),
-        fs.unlink(fileWithValidYaml)
-      ]);
+      await Promise.all([fs.unlink(fileWithSyntaxErrors), fs.unlink(fileWithValidJson), fs.unlink(fileWithValidYaml)]);
     });
 
     it('must reject when file cannot be found', async () => {
-      await expect(loadServiceDefinition(path.join(tmpdir(), uuidv4())))
-        .rejects.toThrow(/Failed to read service definition file.*/);
+      await expect(loadServiceDefinition(path.join(tmpdir(), uuidv4()))).rejects.toThrow(
+        /Failed to read service definition file.*/
+      );
     });
 
     it('must reject when file cannot be parsed', async () => {
-      await expect(loadServiceDefinition(fileWithSyntaxErrors))
-        .rejects.toThrow(/Failed to parse service definition file.*/);
+      await expect(loadServiceDefinition(fileWithSyntaxErrors)).rejects.toThrow(
+        /Failed to parse service definition file.*/
+      );
     });
 
     it('must successfully load JSON files', async () => {
@@ -62,19 +60,15 @@ Object {
     const outputfile = path.join(tmpdir(), `${uuidv4()}-valid.yml`);
 
     afterAll(async () => {
-      await Promise.all([
-        fs.unlink(outputfile)
-      ]);
+      await Promise.all([fs.unlink(outputfile)]);
     });
 
     it('must successfully write YAML files', async () => {
-      await writeServiceDefinition(outputfile, { id: '00000000-0000-0000-0000-000000000000', name: 'Test ServiceDefinition', mapping: {} });
+      await writeServiceDefinition(outputfile, { name: 'Test ServiceDefinition', mapping: {} });
 
-      expect((await fs.readFile(outputfile)).toString()).toEqual(`id: 00000000-0000-0000-0000-000000000000
-name: Test ServiceDefinition
+      expect((await fs.readFile(outputfile)).toString()).toEqual(`name: Test ServiceDefinition
 mapping: {}
 `);
     });
-
   });
 });

--- a/src/serviceDefinition/files.ts
+++ b/src/serviceDefinition/files.ts
@@ -5,7 +5,7 @@ import fs from 'fs/promises';
 import yaml from 'js-yaml';
 
 import { abortExecution } from '../errors';
-import { ServiceDefinition } from './types';
+import { DefineServiceDefinition, ServiceDefinition } from './types';
 
 export async function loadServiceDefinition(serviceDefinitionPath: string): Promise<ServiceDefinition> {
   let fileContent: string;
@@ -13,7 +13,7 @@ export async function loadServiceDefinition(serviceDefinitionPath: string): Prom
     fileContent = await fs.readFile(serviceDefinitionPath, { encoding: 'utf8' });
   } catch (e) {
     throw abortExecution(
-      'Failed to read service definition file at path \'%s\': %s',
+      "Failed to read service definition file at path '%s': %s",
       serviceDefinitionPath,
       (e as Error)?.message ?? 'Unknown Cause'
     );
@@ -23,14 +23,17 @@ export async function loadServiceDefinition(serviceDefinitionPath: string): Prom
     return yaml.load(fileContent) as ServiceDefinition;
   } catch (e) {
     throw abortExecution(
-      'Failed to parse service definition file at path \'%s\' as YAML/JSON: %s',
+      "Failed to parse service definition file at path '%s' as YAML/JSON: %s",
       serviceDefinitionPath,
       (e as Error)?.message ?? 'Unknown Cause'
     );
   }
 }
 
-export async function writeServiceDefinition(serviceDefinitionPath: string, serviceDefinition: ServiceDefinition): Promise<void> {
+export async function writeServiceDefinition(
+  serviceDefinitionPath: string,
+  serviceDefinition: DefineServiceDefinition
+): Promise<void> {
   const fileContent = yaml.dump(serviceDefinition);
   await fs.writeFile(serviceDefinitionPath, fileContent, { encoding: 'utf8' });
 }

--- a/src/serviceDefinition/init.ts
+++ b/src/serviceDefinition/init.ts
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2022 Steadybit GmbH
 
-import { KubernetesMapping, Parameters, PolicyReference, ServiceDefinition } from './types';
+import { DefineServiceDefinition, KubernetesMapping, Parameters, PolicyReference } from './types';
 import { validateHttpUrl, validateNotBlank } from '../prompt/validation';
 import { abortExecutionWithError } from '../errors';
 import { writeServiceDefinition } from './files';
 import { confirm } from '../prompt/confirm';
 import { getAllTeams } from '../team/get';
 import { Team } from '../team/types';
-import { v4 as uuidv4 } from 'uuid';
 import colors from 'colors/safe';
 import inquirer from 'inquirer';
 import yaml from 'js-yaml';
@@ -38,7 +37,7 @@ export async function init() {
   console.log(`  ${colors.bold('steadybit service apply')}`);
 }
 
-async function askForServiceDefinitionInformation(): Promise<ServiceDefinition> {
+async function askForServiceDefinitionInformation(): Promise<DefineServiceDefinition> {
   let teams: Team[];
   try {
     teams = await getAllTeams();
@@ -65,7 +64,6 @@ async function askForServiceDefinitionInformation(): Promise<ServiceDefinition> 
   const parameters = await askForParameters(teams);
 
   return {
-    id: uuidv4(),
     name: answers.name,
     policies,
     mapping: {

--- a/src/serviceDefinition/types.d.ts
+++ b/src/serviceDefinition/types.d.ts
@@ -38,8 +38,7 @@ export interface TaskReference extends ReferenceCoordinate {
   forEach?: ForEach[];
 }
 
-export interface ServiceDefinition {
-  id: string;
+export interface DefineServiceDefinition {
   name: string;
   policies?: PolicyReference[];
   tasks?: TaskReference[];
@@ -48,13 +47,8 @@ export interface ServiceDefinition {
   tags?: Record<string, string>;
 }
 
-export interface DefineServiceDefinition {
-  name: string;
-  policies?: PolicyReference[];
-  tasks?: TaskReference[];
-  mapping: Mapping;
-  parameters?: Parameters;
-  tags?: Record<string, string>;
+export interface ServiceDefinition extends DefineServiceDefinition {
+  id: string;
 }
 
 export type Parameters = Record<string, any>;

--- a/src/serviceDefinition/types.d.ts
+++ b/src/serviceDefinition/types.d.ts
@@ -48,6 +48,15 @@ export interface ServiceDefinition {
   tags?: Record<string, string>;
 }
 
+export interface DefineServiceDefinition {
+  name: string;
+  policies?: PolicyReference[];
+  tasks?: TaskReference[];
+  mapping: Mapping;
+  parameters?: Parameters;
+  tags?: Record<string, string>;
+}
+
 export type Parameters = Record<string, any>;
 
 export type TaskState = 'PENDING' | 'SUCCESS' | 'FAILURE';


### PR DESCRIPTION
# Why

We've added a new endpoint to create services without IDs. The backend now contains the logic to calculate a proper one.

# References
[Backend PR](https://github.com/steadybit/platform/pull/402)