### PR TITLE
feat: allow directories for --file parameter

### DIFF
--- a/src/cli/steadybit-experiment.ts
+++ b/src/cli/steadybit-experiment.ts
@@ -3,9 +3,9 @@
 // SPDX-FileCopyrightText: 2022 Steadybit GmbH
 
 import { Command, Option } from 'commander';
-import { executeExperiment } from '../experiment/exec';
+import { executeExperiments } from '../experiment/exec';
 import { getExperiment } from '../experiment/get';
-import { applyExperiment } from '../experiment/apply';
+import { applyExperiments } from '../experiment/apply';
 import { deleteExperiment } from '../experiment/delete';
 import { requirePlatformAccess } from './requirements';
 
@@ -16,10 +16,11 @@ program
   .alias('exec')
   .description('Executes an experiment run. If a file is specified the experiment is saved before execution.')
   .addOption(new Option('-k, --key <key>', 'The experiment key.').conflicts('file'))
-  .addOption(new Option('-f, --file <file>', 'The path to the experiment file.').conflicts('key'))
+  .addOption(new Option('-f, --file <files...>', 'The path to the experiment file or a directory containing multiple files.').conflicts('key'))
+  .addOption(new Option('-R, --recursive', 'Process the directory used in -f, --file recursively. Useful when you want to manage related experiments organized within the same directory.').default(false))
   .addOption(new Option('--no-wait', 'Do not wait for experiment run to finish.'))
   .addOption(new Option('--yes', 'Skip the prompt asking for experiment run confirmation. Not necessary when no TTY is attached.').default(false))
-  .action(requirePlatformAccess(executeExperiment));
+  .action(requirePlatformAccess(executeExperiments));
 
 program
   .command('get')
@@ -32,8 +33,9 @@ program
   .command('apply')
   .description('Upload an experiment to Steadybit. If a key is provided, an update is performed. Otherwise, the externalId from the yaml is used to create or update the experiment.')
   .addOption(new Option('-k, --key <key>', 'The experiment key.'))
-  .addOption(new Option('-f, --file <file>', 'The path to the experiment file.').makeOptionMandatory(true))
-  .action(requirePlatformAccess(applyExperiment));
+  .addOption(new Option('-f, --file <files...>', 'The path to the experiment file or a directory containing multiple files').makeOptionMandatory(true))
+  .addOption(new Option('-R, --recursive', 'Process the directory used in -f, --file recursively. Useful when you want to manage related experiments organized within the same directory.').default(false))
+  .action(requirePlatformAccess(applyExperiments));
 
 program
   .command('delete')

--- a/src/experiment/api.ts
+++ b/src/experiment/api.ts
@@ -59,7 +59,7 @@ export async function updateExperiment(key: string, experiment: Experiment): Pro
     });
   } catch (e: any) {
     if (e.response.status === 404) {
-      throw await abortExecutionWithError('Experiment %s not found.', key);
+      throw abortExecution('Experiment %s not found.', key);
     } else {
       throw await abortExecutionWithError(e, 'Failed to save the experiment. HTTP request failed.');
     }

--- a/src/experiment/apply.ts
+++ b/src/experiment/apply.ts
@@ -1,28 +1,41 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2022 Steadybit GmbH
 
-import { loadExperiment, writeExperiment } from './files';
+import { loadExperiment, resolveExperimentFiles, writeExperiment } from './files';
 import { updateExperiment, upsertExperiment } from './api';
+import { abortExecution } from '../errors';
 
 export interface Options {
   key?: string;
-  file: string;
+  file: string[];
+  recursive: boolean;
 }
 
-export async function applyExperiment(options: Options) {
-  const experiment = await loadExperiment(options.file);
+export async function applyExperiments(options: Options) {
+  const files = await resolveExperimentFiles(options.file, options.recursive);
 
-  const key = options.key || experiment.key;
-  if (key) {
-    await updateExperiment(key, experiment);
-    console.log('Experiment %s updated.', key);
-  } else {
-    const result = await upsertExperiment(experiment);
-    if (result.created) {
-      await writeExperiment(options.file, {key: result.key, ...experiment});
-      console.log('Experiment %s created.', result.key);
+  if (options.key && files.length > 1) {
+    throw abortExecution('If --key is specified, at most one --file can be specified.');
+  }
+
+  for (const file of files) {
+    const experiment = await loadExperiment(file);
+    const key = options.key || experiment.key;
+
+    console.log('key: ', key, 'file: ', file);
+
+
+    if (key) {
+      await updateExperiment(key, experiment);
+      console.log('Experiment %s updated.', key);
     } else {
-      console.log('Experiment %s updated.', result.key);
+      const result = await upsertExperiment(experiment);
+      if (result.created) {
+        await writeExperiment(file, { key: result.key, ...experiment });
+        console.log('Experiment %s created.', result.key);
+      } else {
+        console.log('Experiment %s updated.', result.key);
+      }
     }
   }
 }

--- a/src/experiment/files.test.ts
+++ b/src/experiment/files.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+import { getTempDir, writeYamlFile } from '../mocks/tempFiles';
+import { resolveExperimentFiles } from './files';
+
+
+describe('experiment/files', () => {
+  describe('resolveExperimentFiles', () => {
+    let files: string[];
+    let nestedFiles: string[];
+
+    beforeAll(async () => {
+      files = await Promise.all([
+        writeYamlFile('experiment.yaml', {}),
+        writeYamlFile('experiment.yml', {})
+      ]);
+      nestedFiles = await Promise.all([
+        writeYamlFile('nested/experiment.yaml', {}),
+        writeYamlFile('nested/experiment.yml', {})
+      ]);
+      await Promise.all([
+        writeYamlFile('other.txt', {}),
+        writeYamlFile('nested/other.txt', {})
+      ]);
+    });
+
+    it('should resolve all files recursive', async () => {
+      expect(await resolveExperimentFiles([getTempDir()], true)).toEqual([...files, ...nestedFiles]);
+    });
+    it('should resolve files non-recursive', async () => {
+      expect(await resolveExperimentFiles([getTempDir()], false)).toEqual(files);
+    });
+    it('should resolve files directly', async () => {
+      expect(await resolveExperimentFiles(files, false)).toEqual(files);
+    });
+    it('should resolve empty files', async () => {
+      expect(await resolveExperimentFiles([], false)).toEqual([]);
+    });
+  });
+});

--- a/src/experiment/get.test.ts
+++ b/src/experiment/get.test.ts
@@ -3,23 +3,14 @@
 
 import { getExperiment } from './get';
 import path from 'path';
-import * as os from 'os';
 import fs from 'fs/promises';
+import { getTempDir } from '../mocks/tempFiles';
 
 describe('experiment', () => {
-  let tmpFolder: string;
-
-  beforeAll(async () => {
-    tmpFolder = await fs.mkdtemp(path.join(os.tmpdir(), 'steadybit-cli-test'));
-  });
-
-  afterAll(async () => {
-    await fs.rm(tmpFolder, { recursive: true });
-  });
-
   describe('get', () => {
     it('should output experiment to file', async () => {
-      const file = path.join(tmpFolder, 'experiment.yaml');
+      const file = path.join(getTempDir(), 'experiment.yaml');
+
       await getExperiment({ key: 'TST-1', file });
 
       const content = await fs.readFile(file, 'utf-8');
@@ -27,7 +18,7 @@ describe('experiment', () => {
     });
 
     it('should report not found', async () => {
-        await expect(getExperiment({ key: 'TST-999' })).rejects.toThrow('Experiment TST-999 not found.');
+      await expect(getExperiment({ key: 'TST-999' })).rejects.toThrow('Experiment TST-999 not found.');
     });
   });
 });

--- a/src/experiment/types.d.ts
+++ b/src/experiment/types.d.ts
@@ -19,7 +19,6 @@ export type UpsertResult = {
   key?: string;
 };
 
-export type UpsertAndExecuteResult = {
-  location?: string;
+export type UpsertAndExecuteResult = ExecuteResult & {
   key?: string;
 }

--- a/src/mocks/tempFiles.ts
+++ b/src/mocks/tempFiles.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import yaml from 'js-yaml';
+
+let tempDir: string;
+
+export async function createTempDir() {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'steadybit-cli-test'));
+}
+
+export async function writeYamlFile(name: string, content: any) {
+  const file = path.join(tempDir, name);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, yaml.dump(content));
+  return file;
+}
+
+export function getTempDir() {
+  return tempDir;
+}
+
+export async function removeTempDir() {
+  await fs.rm(tempDir, { recursive: true });
+}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,12 +2,26 @@
 // SPDX-FileCopyrightText: 2022 Steadybit GmbH
 
 import { server } from './mocks/server';
+import { resetExperiments } from './mocks/handlers';
+import { createTempDir, removeTempDir } from './mocks/tempFiles';
 
-process.env.STEADYBIT_URL = 'http://test'
-process.env.STEADYBIT_TOKEN = 'abcdefgh'
+process.env.STEADYBIT_URL = 'http://test';
+process.env.STEADYBIT_TOKEN = 'abcdefgh';
 
-beforeAll(() => server.listen());
+beforeAll(async () => {
+  await createTempDir();
+  server.listen();
+});
 
-afterEach(() => server.resetHandlers());
+beforeEach(async () => {
+  resetExperiments();
+});
 
-afterAll(() => server.close());
+afterEach(async () => {
+  server.resetHandlers();
+});
+
+afterAll(async () => {
+  await removeTempDir();
+  server.close();
+});


### PR DESCRIPTION
allow to specify multiple --file parameters and using directories in order to apply / execute multiple experiments within a single call